### PR TITLE
Efro wild-type mutant probability

### DIFF
--- a/test/features/test_neighbour_profile.py
+++ b/test/features/test_neighbour_profile.py
@@ -6,8 +6,7 @@ import h5py
 from nose.tools import ok_
 
 from deeprank.features.neighbour_profile import (__compute_feature__,
-                                                 IC_FEATURE_NAME,
-                                                 get_probability_feature_name)
+                                                 IC_FEATURE_NAME, WT_FEATURE_NAME, MUT_FEATURE_NAME)
 from deeprank.models.mutant import PdbMutantSelection
 
 
@@ -25,7 +24,8 @@ def test_feature():
             __compute_feature__(mutant.pdb_path, group, None, mutant)
 
             # Check that the features are present on the grid:
-            ok_(len(group.get(get_probability_feature_name("ALA"))) > 0)
+            ok_(len(group.get(WT_FEATURE_NAME)) > 0)
+            ok_(len(group.get(MUT_FEATURE_NAME)) > 0)
             ok_(len(group.get(IC_FEATURE_NAME)) > 0)
     finally:
         rmtree(tmp_dir_path)


### PR DESCRIPTION
The change makes sure that the probability scores of the mutant and wild-type amino acids are included as features. This is done instead of the probabilities for all the amino acids, as was done earlier.

Since deeprank maps all features to a 3D grid, this feature needs to be given a position in the structure as well. To solve this problem, the feature has been given the position of the variant residue's C-alpha. This will also place the feature at the grid's center.